### PR TITLE
Implement

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,1 @@
+[inputs: ["mix.exs", "{lib,test}/**/*.{ex,exs}"]]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_build
+/deps/
+/priv/

--- a/lib/fsentry.ex
+++ b/lib/fsentry.ex
@@ -1,0 +1,32 @@
+defmodule FSentry do
+  @on_load :load
+
+  def load do
+    :erl_ddll.load_driver(:code.priv_dir(:fsentry), 'fsentry')
+  end
+
+  def start(self_pid \\ self(), path) do
+    pid = spawn_link(fn -> watch(self_pid, open_port(path)) end)
+    {:ok, pid}
+  end
+
+  def stop(pid) do
+    send(pid, :stop)
+    :ok
+  end
+
+  defp open_port(path) do
+    Port.open({:spawn_driver, ['fsentry #{path}']}, [:in])
+  end
+
+  defp watch(pid, port) do
+    receive do
+      {^port, path, message} ->
+        send(pid, {self(), path, message})
+      :stop ->
+        exit(:stop)
+    end
+
+    watch(pid, port)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,24 @@
+defmodule FSentry.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :fsentry,
+      version: "0.0.0",
+      aliases: ["compile.fsentry": &compile/1]
+      #      compilers: Mix.compilers() ++ [:fsentry]
+    ]
+  end
+
+  def compile(_) do
+    File.mkdir_p!("priv")
+
+    include = [:code.root_dir(), "/erts-", :erlang.system_info(:version), "/include"]
+    args = ["-shared", "-I#{include}", "src/fsentry_inotify.c", "-o", "priv/fsentry.so"]
+
+    case System.cmd("cc", args) do
+      0 -> :ok
+      _ -> {:error, []}
+    end
+  end
+end

--- a/src/fsentry_inotify.c
+++ b/src/fsentry_inotify.c
@@ -1,0 +1,118 @@
+#include <limits.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/inotify.h>
+
+#include "erl_driver.h"
+
+#define BUFLEN (NAME_MAX + 1 + sizeof(struct inotify_event)) * 16
+#define LENGTH(x) sizeof(x) / sizeof(*x)
+
+struct state {
+  ErlDrvPort port;
+  int fd;
+  int wd;
+};
+
+static ErlDrvData start(ErlDrvPort port, char *command) {
+  command += LENGTH("fsentry");
+
+  struct state *state = driver_alloc(sizeof(*state));
+
+  if (!state)
+    return ERL_DRV_ERROR_GENERAL;
+
+  state->port = port;
+  state->fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+  if (state->fd == -1) {
+    driver_free(state);
+    return ERL_DRV_ERROR_ERRNO;
+  }
+
+  state->wd = inotify_add_watch(state->fd, command, IN_ALL_EVENTS);
+
+  if (state->wd == -1) {
+    close(state->fd);
+    driver_free(state);
+    return ERL_DRV_ERROR_ERRNO;
+  }
+
+  driver_select(state->port, (ErlDrvEvent)(intptr_t)state->fd,
+                ERL_DRV_READ | ERL_DRV_USE, 1);
+
+  return (ErlDrvData)state;
+}
+
+static void stop(ErlDrvData data) {
+  struct state *state = (struct state *)data;
+  driver_select(state->port, (ErlDrvEvent)(intptr_t)state->fd, ERL_DRV_USE, 0);
+  close(state->fd);
+  driver_free(state);
+}
+
+char *inotify_event_to_string(struct inotify_event *i) {
+  if (i->mask & IN_ACCESS)
+    return "access";
+  if (i->mask & IN_CREATE)
+    return "create";
+  if (i->mask & IN_DELETE)
+    return "delete";
+  if (i->mask & IN_MODIFY)
+    return "modify";
+  if (i->mask & IN_OPEN)
+    return "open";
+
+  return "unknown";
+}
+
+void ready_input(ErlDrvData data, ErlDrvEvent event) {
+  struct state *state = (struct state *)data;
+  int fd = (intptr_t)event;
+
+  for (;;) {
+    char buf[BUFLEN];
+    char *ptr = buf;
+
+    int n = read(fd, buf, BUFLEN);
+
+    if (n <= 0)
+      break;
+
+    while (ptr < buf + n) {
+      struct inotify_event *if_event = (struct inotify_event *)ptr;
+
+      ErlDrvBinary *name = driver_alloc_binary(if_event->len - 1);
+      memcpy(name->orig_bytes, &if_event->name, name->orig_size);
+
+      ErlDrvTermData term[] = {
+          ERL_DRV_PORT,   driver_mk_port(state->port),
+          ERL_DRV_BINARY, (ErlDrvTermData)name, (ErlDrvTermData)name->orig_size, 0,
+          ERL_DRV_ATOM,   driver_mk_atom(inotify_event_to_string(if_event)),
+          ERL_DRV_TUPLE,  3};
+
+      erl_drv_output_term(driver_mk_port(state->port), term, LENGTH(term));
+      driver_free_binary(name);
+
+      ptr += sizeof(struct inotify_event) + if_event->len;
+    }
+  }
+}
+
+static void stop_select(ErlDrvEvent event, void *reserved) {
+  close((intptr_t)event);
+}
+
+static ErlDrvEntry driver_entry = {
+    .init = NULL,
+    .start = start,
+    .stop = stop,
+    .ready_input = ready_input,
+    .stop_select = stop_select,
+    .driver_name = "fsentry",
+    .extended_marker = ERL_DRV_EXTENDED_MARKER,
+    .major_version = ERL_DRV_EXTENDED_MAJOR_VERSION,
+    .minor_version = ERL_DRV_EXTENDED_MINOR_VERSION};
+
+DRIVER_INIT(fsentry) { return &driver_entry; }

--- a/test/fsentry_test.exs
+++ b/test/fsentry_test.exs
@@ -1,0 +1,28 @@
+defmodule FSentryTest do
+  use ExUnit.Case
+
+  def all_messages do
+    receive do
+      message ->
+        [message | all_messages()]
+    after
+      0 -> []
+    end
+  end
+
+  test "create/modify/delete events go through" do
+    tmp_dir = System.tmp_dir!()
+    {:ok, pid} = FSentry.start(tmp_dir)
+    tmp_file = Path.join(tmp_dir, "fsentry")
+
+    File.touch!(tmp_file)
+    File.write!(tmp_file, "")
+    File.rm!(tmp_file)
+
+    assert [{_, "fsentry", :create},
+	    {_, "fsentry", :modify},
+	    {_, "fsentry", :delete}] = all_messages()
+
+    FSentry.stop(pid)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,2 @@
+FSentry.load()
+ExUnit.start()


### PR DESCRIPTION
This is a port driver (http://erlang.org/doc/tutorial/c_portdriver.html) implementation of inotify for Elixir. When started, it streams messages with events happening on the given path to the given process.

Most people use https://github.com/synrc/fs, but it isn't fit for LogDriver because it doesn't support listening on individual files, and it creates a process per directory and parses `inotifywait` stdout, which is inefficient, limiting (in terms of `/proc/sys/kernel/pid_max`), and requires `inotify-tools` being installed.