### PR TITLE
Add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
-/deps/
-/priv/
+/deps
+/doc
+/priv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# FSentry
+
+FSentry is an Elixir module for spawning FS sentries. It is implemented as a
+[port driver][] that streams FS event messages to a designated PID.
+
+[port driver]: http://erlang.org/doc/tutorial/c_portdriver.html
+
+Currently, only Inotify backend is implemented, although Kqueue and Win32
+implementations are planned.
+
+Unlike [synrc/fs](https://github.com/synrc/fs), FSentry doesn't spawn external
+processes and doesn't have any runtime dependencies. It also can listen on
+individual files rather than just folders.

--- a/lib/fsentry.ex
+++ b/lib/fsentry.ex
@@ -1,24 +1,44 @@
 defmodule FSentry do
-  @on_load :load
+  @moduledoc """
+    Module for creating (eventually) cross-platform file system sentries.
+  """
 
+  @doc """
+    Load native port driver.
+  """
+  @spec load :: :ok | {:error, reason :: term()}
   def load do
     :erl_ddll.load_driver(:code.priv_dir(:fsentry), 'fsentry')
   end
 
-  def start(self_pid \\ self(), path) do
-    pid = spawn_link(fn -> watch(self_pid, open_port(path)) end)
-    {:ok, pid}
+  @doc """
+    Start sentry listening for changes on path, returns PID.
+
+    Change events are sent to `self_pid` and assume `{sentry_pid, path, message}`
+    format where `message` is `:create | :modify | :delete`.
+  """
+  @spec start!(pid(), Path.t()) :: pid()
+  def start!(self_pid \\ self(), path) do
+    spawn_link(fn -> watch(self_pid, open_port(path)) end)
   end
 
+  @doc """
+    Stop sentry by PID.
+  """
+  @spec stop(pid()) :: :ok
   def stop(pid) do
     send(pid, :stop)
     :ok
   end
 
+  # Create port driver instance listening on given path.
+  @spec open_port(Path.t()) :: port()
   defp open_port(path) do
-    Port.open({:spawn_driver, ['fsentry #{path}']}, [:in])
+    Port.open({:spawn_driver, "fsentry #{path}"}, [:in])
   end
 
+  # Listen for port driver events and retransmit them to given PID. Exit on :stop.
+  @spec watch(pid(), port()) :: no_return()
   defp watch(pid, port) do
     receive do
       {^port, path, message} ->

--- a/lib/fsentry/application.ex
+++ b/lib/fsentry/application.ex
@@ -1,0 +1,24 @@
+defmodule FSentry.Application do
+  @moduledoc """
+    Fake application that loads native port driver.
+  """
+
+  @behaviour Application
+
+  def start(_, _) do
+    case FSentry.load() do
+      :ok -> {:ok, spawn_link(&loop/0)}
+      err -> err
+    end
+  end
+
+  def stop(_) do
+    :ok
+  end
+
+  @spec loop :: no_return()
+  defp loop do
+    receive do
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,9 +4,19 @@ defmodule FSentry.MixProject do
   def project do
     [
       app: :fsentry,
-      version: "0.0.0",
-      aliases: ["compile.fsentry": &compile/1]
+      version: "0.1.0",
+      aliases: ["compile.fsentry": &compile/1],
+      compilers: [:fsentry] ++ Mix.compilers(),
+      deps: [
+        {:dialyxir, "~> 0.5", only: :dev, runtime: false},
+        {:ex_doc, "~> 0.18.0", only: :dev, runtime: false}
+      ],
+      links: %{"GitHub" => "https://github.com/serokell/fsentry"}
     ]
+  end
+
+  def application do
+    [mod: {FSentry.Application, []}]
   end
 
   def compile(_) do
@@ -16,8 +26,8 @@ defmodule FSentry.MixProject do
     args = ["-shared", "-I#{include}", "src/fsentry_inotify.c", "-o", "priv/fsentry.so"]
 
     case System.cmd("cc", args) do
-      0 -> :ok
-      _ -> {:error, []}
+      {_, 0} -> :ok
+      {_, _} -> Mix.raise("could not build fsentry port driver")
     end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,9 @@
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "fsentry";
+  buildInputs = [ elixir ];
+}

--- a/src/fsentry_inotify.c
+++ b/src/fsentry_inotify.c
@@ -4,6 +4,7 @@
 
 #include <sys/inotify.h>
 
+// http://erlang.org/doc/man/erl_driver.html
 #include "erl_driver.h"
 
 #define BUFLEN (NAME_MAX + 1 + sizeof(struct inotify_event)) * 16

--- a/test/fsentry_test.exs
+++ b/test/fsentry_test.exs
@@ -10,13 +10,13 @@ defmodule FSentryTest do
   end
 
   test "create/modify/delete events go through" do
-    tmp_dir = System.tmp_dir!()
-    {:ok, pid} = FSentry.start(tmp_dir)
-    tmp_file = Path.join(tmp_dir, "fsentry")
+    tmp = System.tmp_dir!()
+    pid = FSentry.start!(tmp)
+    tmp = Path.join(tmp, "fsentry")
 
-    File.touch!(tmp_file)
-    File.write!(tmp_file, "")
-    File.rm!(tmp_file)
+    File.touch!(tmp)
+    File.write!(tmp, "")
+    File.rm!(tmp)
 
     assert [
              {_, "fsentry", :create},


### PR DESCRIPTION
This also includes small design fixes such as `start/2` -> `start!/2` replacement, Mix `compile.fsentry` task bug fix, and fake OTP app to load port driver (`FSentry.Application`).